### PR TITLE
Add JSON Web Token (JWT) endpoints

### DIFF
--- a/example_project/config/urls.py
+++ b/example_project/config/urls.py
@@ -7,12 +7,15 @@ urlpatterns = [
     url(r'^$', views.HomeSessionView.as_view(), name='home'),
     url(r'^session/$', views.HomeSessionView.as_view(), name='home_session'),
     url(r'^token/$', views.HomeTokenView.as_view(), name='home_token'),
+    url(r'^jwt/$', views.HomeJWTView.as_view(), name='home_jwt'),
 
     url(r'^api/login/', include('rest_social_auth.urls_session')),
     url(r'^api/login/', include('rest_social_auth.urls_token')),
+    url(r'^api/login/', include('rest_social_auth.urls_jwt')),
 
     url(r'^api/logout/session/$', views.LogoutSessionView.as_view(), name='logout_session'),
     url(r'^api/user/session/', views.UserSessionDetailView.as_view(), name="current_user_session"),
     url(r'^api/user/token/', views.UserTokenDetailView.as_view(), name="current_user_token"),
+    url(r'^api/user/jwt/', views.UserJWTDetailView.as_view(), name="current_user_jwt"),
     url(r'^admin/', include(admin.site.urls)),
 ]

--- a/example_project/templates/base.html
+++ b/example_project/templates/base.html
@@ -7,6 +7,7 @@
     <h1>Django-rest-framework and OAuth example</h1>
     <a href="{% url 'home_session' %}">Session auth</a>
     <a href="{% url 'home_token' %}">Token auth</a>
+    <a href="{% url 'home_jwt' %}">JWT auth</a>
 
     {% block content %}
 

--- a/example_project/templates/home_jwt.html
+++ b/example_project/templates/home_jwt.html
@@ -81,6 +81,7 @@
             $authProvider.twitter({
               url: "{% url 'login_social_jwt_user' provider='twitter' %}",
             });
+            $authProvider.authToken = 'JWT';
           }).controller('LoginJWTCtrl', function($scope, $auth, $http) {
             self = this;
 
@@ -105,6 +106,7 @@
             $scope.logout = function(){
                 $auth.removeToken();
                 set_user();
+                self.jwtPayload = $auth.getPayload();
             };
         });
 

--- a/example_project/templates/home_jwt.html
+++ b/example_project/templates/home_jwt.html
@@ -1,0 +1,112 @@
+{% extends "base.html" %}
+{% load staticfiles %}
+
+{% block content %}
+    <div ng-app="JWTApp">
+        <div ng-controller="LoginJWTCtrl as ctrl">
+            <div>
+                <h4>rest_framework_jwt.authentication.JSONWebTokenAuthentication</h4>
+                <div><button ng-click="authenticate('facebook')">Login facebook (OAuth 2.0)</button></div>
+                <div><button ng-click="authenticate('google')">Login google (OAuth 2.0)</button></div>
+                <div><button ng-click="authenticate('twitter')">Login twitter (OAuth 1.0)*</button></div>
+                <div><button ng-click="logout()">Logout jwt</button></div>
+            </div>
+            <div>
+                (*) Currently in case of OAuth 1.0 you still need to have session enabled, as python-social-auth will store some data in session between requests. Maybe in future versions of rest-social-auth this will be solved.
+            </div>
+            <div>
+                <h2>JWT user data</h2>
+                <div>
+                    {% verbatim %}
+                    <img ng-src='{{ctrl.user.thumb}}' />
+                    {% endverbatim %}
+                </div>
+                <div>
+                    <span>First name:</span>
+                    <span ng-bind="ctrl.user.first_name"></span>
+                </div>
+                <div>
+                    <span>Last name:</span>
+                    <span ng-bind="ctrl.user.last_name"></span>
+                </div>
+                <div>
+                    <span>Email:</span>
+                    <span ng-bind="ctrl.user.email"></span>
+                </div>
+                <h2>Raw JWT payload</h2>
+                <div>
+                    <pre>{% verbatim %}{{ ctrl.jwtPayload | json }}{% endverbatim %}</pre>
+                </div>
+            </div>
+        </div>
+    </div>
+
+{% endblock content %}
+
+{% block scripts %}
+    {{ block.super }}
+    <script type="text/javascript">
+
+        function set_user(response){
+            var source;
+            if (response){
+                source = response.data;
+            } else {
+                source = {
+                    'username': null,
+                    'first_name': null,
+                    'last_name': null,
+                    'email': null,
+                    'social_thumb': '{% static "anonymous.png" %}'
+                };
+            }
+            self.user.username = source.username;
+            self.user.first_name = source.first_name;
+            self.user.last_name = source.last_name;
+            self.user.email = source.email;
+            self.user.thumb = source.social_thumb;
+        };
+
+        angular.module('JWTApp', ['satellizer'])
+          .config(function($authProvider) {
+            $authProvider.facebook({
+              url: "{% url 'login_social_jwt_user' provider='facebook' %}",
+              clientId: '295137440610143'
+            });
+            $authProvider.google({
+              url: "{% url 'login_social_jwt_user' provider='google-oauth2' %}",
+              clientId: '976099811367-ihbmg1pfnniln9qgfacleiu41bhl3fqn.apps.googleusercontent.com',
+              redirectUri: window.location.origin + '/'
+            });
+            $authProvider.twitter({
+              url: "{% url 'login_social_jwt_user' provider='twitter' %}",
+            });
+          }).controller('LoginJWTCtrl', function($scope, $auth, $http) {
+            self = this;
+
+            self.user = {};
+            set_user();
+            if ($auth.getToken()){
+                $http.get('{% url "current_user_jwt" %}').then(function(response){
+                    set_user(response);
+                });
+            }
+
+            self.jwtPayload = $auth.getPayload();
+
+            $scope.authenticate = function(provider) {
+                $auth.authenticate(provider).then(function(response){
+                    $auth.setToken(response.data.token);
+                    set_user(response);
+                    self.jwtPayload = $auth.getPayload();
+                });
+            };
+
+            $scope.logout = function(){
+                $auth.removeToken();
+                set_user();
+            };
+        });
+
+    </script>
+{% endblock scripts %}

--- a/example_project/users/views.py
+++ b/example_project/users/views.py
@@ -8,6 +8,7 @@ from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_social_auth.serializers import UserSerializer
 from rest_framework.authentication import SessionAuthentication, TokenAuthentication
+from rest_framework_jwt.authentication import JSONWebTokenAuthentication
 
 
 class HomeSessionView(TemplateView):
@@ -20,6 +21,10 @@ class HomeSessionView(TemplateView):
 
 class HomeTokenView(TemplateView):
     template_name = 'home_token.html'
+
+
+class HomeJWTView(TemplateView):
+    template_name = 'home_jwt.html'
 
 
 class LogoutSessionView(APIView):
@@ -44,3 +49,7 @@ class UserSessionDetailView(BaseDeatilView):
 
 class UserTokenDetailView(BaseDeatilView):
     authentication_classes = (TokenAuthentication, )
+
+
+class UserJWTDetailView(BaseDeatilView):
+    authentication_classes = (JSONWebTokenAuthentication, )

--- a/rest_social_auth/serializers.py
+++ b/rest_social_auth/serializers.py
@@ -35,3 +35,18 @@ class TokenSerializer(serializers.Serializer):
 
 class UserTokenSerializer(TokenSerializer, UserSerializer):
     pass
+
+
+class JWTSerializer(TokenSerializer):
+    def get_token(self, obj):
+        jwt_payload_handler = api_settings.JWT_PAYLOAD_HANDLER
+        jwt_encode_handler = api_settings.JWT_ENCODE_HANDLER
+        
+        payload = jwt_payload_handler(obj)  # obj is the user instance
+        token = jwt_encode_handler(payload)
+
+        return token
+
+
+class UserJWTSerializer(JWTSerializer, UserSerializer):
+    pass

--- a/rest_social_auth/serializers.py
+++ b/rest_social_auth/serializers.py
@@ -44,7 +44,7 @@ class JWTSerializer(TokenSerializer):
         try:
             from rest_framework_jwt.settings import api_settings
         except ImportError:
-            l.debug("djangorestframework-jwt required for JWT authentication")
+            l.warning("djangorestframework-jwt required for JWT authentication")
             raise
 
         jwt_payload_handler = api_settings.JWT_PAYLOAD_HANDLER

--- a/rest_social_auth/serializers.py
+++ b/rest_social_auth/serializers.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
+import logging
 from rest_framework import serializers
 from rest_framework.authtoken.models import Token
 from django.contrib.auth import get_user_model
 
+l = logging.getLogger(__name__)
 
 class OAuth2InputSerializer(serializers.Serializer):
     provider = serializers.CharField(required=False)
@@ -39,6 +41,12 @@ class UserTokenSerializer(TokenSerializer, UserSerializer):
 
 class JWTSerializer(TokenSerializer):
     def get_token(self, obj):
+        try:
+            from rest_framework_jwt.settings import api_settings
+        except ImportError:
+            l.debug("djangorestframework-jwt required for JWT authentication")
+            raise
+
         jwt_payload_handler = api_settings.JWT_PAYLOAD_HANDLER
         jwt_encode_handler = api_settings.JWT_ENCODE_HANDLER
         

--- a/rest_social_auth/urls_jwt.py
+++ b/rest_social_auth/urls_jwt.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+from django.conf.urls import patterns, url
+
+from . import views
+
+urlpatterns = patterns('',
+    # returns jwt + user_data
+    url(r'^social/jwt_user/(?:(?P<jwt>[a-zA-Z0-9_-]+)/?)?$', views.SocialJWTUserAuthView.as_view(),
+        name='login_social_jwt_user'),
+    # returns jwt only
+    url(r'^social/jwt/(?:(?P<provider>[a-zA-Z0-9_-]+)/?)?$', views.SocialJWTOnlyAuthView.as_view(),
+        name='login_social_jwt'),
+)

--- a/rest_social_auth/urls_jwt.py
+++ b/rest_social_auth/urls_jwt.py
@@ -5,7 +5,7 @@ from . import views
 
 urlpatterns = patterns('',
     # returns jwt + user_data
-    url(r'^social/jwt_user/(?:(?P<jwt>[a-zA-Z0-9_-]+)/?)?$', views.SocialJWTUserAuthView.as_view(),
+    url(r'^social/jwt_user/(?:(?P<provider>[a-zA-Z0-9_-]+)/?)?$', views.SocialJWTUserAuthView.as_view(),
         name='login_social_jwt_user'),
     # returns jwt only
     url(r'^social/jwt/(?:(?P<provider>[a-zA-Z0-9_-]+)/?)?$', views.SocialJWTOnlyAuthView.as_view(),

--- a/rest_social_auth/views.py
+++ b/rest_social_auth/views.py
@@ -201,6 +201,6 @@ class SocialJWTOnlyAuthView(BaseSocialAuthView):
     authentication_classes = (JSONWebTokenAuthentication, )
 
 
-class SocialTokenUserAuthView(BaseSocialAuthView):
+class SocialJWTUserAuthView(BaseSocialAuthView):
     serializer_class = UserJWTSerializer
     authentication_classes = (JSONWebTokenAuthentication, )

--- a/rest_social_auth/views.py
+++ b/rest_social_auth/views.py
@@ -21,7 +21,11 @@ from rest_framework.generics import GenericAPIView
 from rest_framework.response import Response
 from rest_framework import status
 from rest_framework.authentication import TokenAuthentication
-from rest_framework_jwt.authentication import JSONWebTokenAuthentication
+try:
+    from rest_framework_jwt.authentication import JSONWebTokenAuthentication
+except ImportError:
+    # this is only needed for JWT auth
+    pass
 from requests.exceptions import HTTPError
 
 from .serializers import (OAuth2InputSerializer, OAuth1InputSerializer, UserSerializer,

--- a/rest_social_auth/views.py
+++ b/rest_social_auth/views.py
@@ -21,17 +21,18 @@ from rest_framework.generics import GenericAPIView
 from rest_framework.response import Response
 from rest_framework import status
 from rest_framework.authentication import TokenAuthentication
-try:
-    from rest_framework_jwt.authentication import JSONWebTokenAuthentication
-except ImportError:
-    # this is only needed for JWT auth
-    pass
 from requests.exceptions import HTTPError
 
 from .serializers import (OAuth2InputSerializer, OAuth1InputSerializer, UserSerializer,
     TokenSerializer, UserTokenSerializer, JWTSerializer, UserJWTSerializer)
 
 l = logging.getLogger(__name__)
+
+try:
+    from rest_framework_jwt.authentication import JSONWebTokenAuthentication
+except ImportError:
+    # this is only needed for JWT auth
+    l.warning("djangorestframework-jwt required for JWT autthentication")
 
 
 REDIRECT_URI = getattr(settings, 'REST_SOCIAL_OAUTH_REDIRECT_URI', '/')

--- a/rest_social_auth/views.py
+++ b/rest_social_auth/views.py
@@ -21,10 +21,11 @@ from rest_framework.generics import GenericAPIView
 from rest_framework.response import Response
 from rest_framework import status
 from rest_framework.authentication import TokenAuthentication
+from rest_framework_jwt.authentication import JSONWebTokenAuthentication
 from requests.exceptions import HTTPError
 
 from .serializers import (OAuth2InputSerializer, OAuth1InputSerializer, UserSerializer,
-    TokenSerializer, UserTokenSerializer)
+    TokenSerializer, UserTokenSerializer, JWTSerializer, UserJWTSerializer)
 
 l = logging.getLogger(__name__)
 
@@ -189,3 +190,13 @@ class SocialTokenOnlyAuthView(BaseSocialAuthView):
 class SocialTokenUserAuthView(BaseSocialAuthView):
     serializer_class = UserTokenSerializer
     authentication_classes = (TokenAuthentication, )
+
+
+class SocialJWTOnlyAuthView(BaseSocialAuthView):
+    serializer_class = JWTSerializer
+    authentication_classes = (JSONWebTokenAuthentication, )
+
+
+class SocialTokenUserAuthView(BaseSocialAuthView):
+    serializer_class = UserJWTSerializer
+    authentication_classes = (JSONWebTokenAuthentication, )


### PR DESCRIPTION
Added JWT support with the help of [REST framework JWT Auth](http://getblimp.github.io/django-rest-framework-jwt/#extending-jsonwebtokenauthentication) (issue #6). Adds endpoints for returning a JWT from a social code. This makes [REST framework JWT Auth](http://getblimp.github.io/django-rest-framework-jwt/#extending-jsonwebtokenauthentication) an optional dependency.

Also added JWT example to the example app.