### PR TITLE
Handle HttpResponses returned by the pipeline

### DIFF
--- a/example_project/config/settings.py
+++ b/example_project/config/settings.py
@@ -132,6 +132,7 @@ SOCIAL_AUTH_PIPELINE = (
     'social.pipeline.social_auth.social_details',
     'social.pipeline.social_auth.social_uid',
     'social.pipeline.social_auth.auth_allowed',
+    'users.social_pipeline.check_for_email',
     'social.pipeline.social_auth.social_user',
     'social.pipeline.user.get_username',
     'social.pipeline.user.create_user',

--- a/example_project/users/social_pipeline.py
+++ b/example_project/users/social_pipeline.py
@@ -1,4 +1,5 @@
 import hashlib
+from rest_framework.response import Response
 
 
 def auto_logout(*args, **kwargs):
@@ -27,3 +28,8 @@ def save_avatar(strategy, details, user=None, *args, **kwargs):
         if social_thumb and user.social_thumb != social_thumb:
             user.social_thumb = social_thumb
             strategy.storage.user.changed(user)
+
+
+def check_for_email(backend, uid, user=None, *args, **kwargs):
+    if not kwargs['details'].get('email'):
+        return Response({'error': "Email wasn't provided by facebook"}, status=400)

--- a/rest_social_auth/views.py
+++ b/rest_social_auth/views.py
@@ -16,6 +16,7 @@ from social.backends.oauth import BaseOAuth1
 from social.strategies.utils import get_strategy
 from social.utils import user_is_authenticated, parse_qs
 from social.apps.django_app.views import _do_login as social_auth_login
+from django.http import HttpResponse
 from social.exceptions import AuthException
 from rest_framework.generics import GenericAPIView
 from rest_framework.response import Response
@@ -23,7 +24,6 @@ from rest_framework import status
 from rest_framework.authentication import TokenAuthentication
 from rest_framework.permissions import AllowAny
 from requests.exceptions import HTTPError
-
 from .serializers import (OAuth2InputSerializer, OAuth1InputSerializer, UserSerializer,
     TokenSerializer, UserTokenSerializer, JWTSerializer, UserJWTSerializer)
 
@@ -110,6 +110,8 @@ class BaseSocialAuthView(GenericAPIView):
             user = self.get_object()
         except (AuthException, HTTPError) as e:
             return self.respond_error(e)
+        if isinstance(user, HttpResponse):  # An error happened and pipeline returned HttpResponse instead of user
+            return user
         resp_data = self.get_serializer(instance=user)
         self.do_login(request.backend, user)
         return Response(resp_data.data)

--- a/tests/test_social.py
+++ b/tests/test_social.py
@@ -328,6 +328,17 @@ class TestSocialAuth2(APITestCase, BaseFacebookAPITestCase):
             reverse('login_social_session'),
             {'provider': 'facebook', 'code': '3D52VoM1uiw94a1ETnGvYlCw'})
 
+    def test_user_login_with_no_email(self):
+        user_data_body = json.loads(self.user_data_body)
+        user_data_body['email'] = ''
+        self.user_data_body = json.dumps(user_data_body)
+        self.do_rest_login()
+        resp = self.client.post(
+            reverse('login_social_token'), data={'provider': 'facebook', 'code': '3D52VoM1uiw94a1ETnGvYlCw'}
+        )
+        self.assertEqual(resp.status_code, 400)
+        self.assertIn('error', resp.data)
+
 
 class TestSocialAuth2Error(APITestCase, BaseFacebookAPITestCase):
     access_token_status = 400


### PR DESCRIPTION
Not sure if there's an alternative for this so i thought I'd ask and show you how I'd do this is the same time. 
One of the most important use cases on the pipeline it to return HttpResponses in case or errors or facing missing data like if your facebook uses a phone number with no email address.
If you read this part in the documentation, you'll find that django-social-auth was built with that in mind
http://psa.matiasaguirre.net/docs/developer_intro.html#understanding-the-pipeline
Anyway, this case wasn't handled in the BaseSocialAuthView so I thought I'd change that. :)