### PR TITLE
make the logging of failed social auth optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,6 +361,11 @@ Settings
     I.e. if this settings is defined, other will be ignored.
     But `redirect_uri` param from request has higher priority than any setting.
 
+- `REST_SOCIAL_LOG_AUTH_EXCEPTIONS`
+
+    Default: `True`
+
+    When `False` will not log social auth authentication exceptions.
 
 
 Customization

--- a/rest_social_auth/views.py
+++ b/rest_social_auth/views.py
@@ -36,6 +36,7 @@ l = logging.getLogger(__name__)
 
 REDIRECT_URI = getattr(settings, 'REST_SOCIAL_OAUTH_REDIRECT_URI', '/')
 DOMAIN_FROM_ORIGIN = getattr(settings, 'REST_SOCIAL_DOMAIN_FROM_ORIGIN', True)
+LOG_AUTH_EXCEPTIONS = getattr(settings, 'REST_SOCIAL_LOG_AUTH_EXCEPTIONS', True)
 
 
 def load_strategy(request=None):
@@ -175,7 +176,8 @@ class BaseSocialAuthView(GenericAPIView):
 
     def respond_error(self, error):
         if isinstance(error, Exception):
-            self.log_exception(error)
+            if not isinstance(error, AuthException) or LOG_AUTH_EXCEPTIONS:
+                self.log_exception(error)
         else:
             l.error(error)
         return Response(status=status.HTTP_400_BAD_REQUEST)


### PR DESCRIPTION
make the logging of failed authentication requests optional using a settings value