### PR TITLE
Updating social-auth-core to v3.0.0 to migrate away from Google+ API's

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Requirements
 - python (2.7, 3.5, 3.6)
 - django (1.11, 2.0, 2.1)
 - djangorestframework (>=3.1, <4.0)
-- social-auth-core (>=1.7.0, <2.0)
+- social-auth-core (>=1.7.0, <3.0)
 - social-auth-app-django (>=3.1, <4.0)
 - [optional] djangorestframework-jwt (>=1.7.2)
 - [optional] django-rest-knox (>=3.2.0)

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Requirements
 - python (2.7, 3.5, 3.6)
 - django (1.11, 2.0, 2.1)
 - djangorestframework (>=3.1, <4.0)
-- social-auth-core (>=1.7.0, <3.0)
+- social-auth-core (>=1.7.0, <=3.0)
 - social-auth-app-django (>=3.1, <4.0)
 - [optional] djangorestframework-jwt (>=1.7.2)
 - [optional] django-rest-knox (>=3.2.0)

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Requirements
 - python (2.7, 3.5, 3.6)
 - django (1.11, 2.0, 2.1)
 - djangorestframework (>=3.1, <4.0)
-- social-auth-core (>=1.7.0, <=3.0)
+- social-auth-core (>=3.0, <4.0)
 - social-auth-app-django (>=3.1, <4.0)
 - [optional] djangorestframework-jwt (>=1.7.2)
 - [optional] django-rest-knox (>=3.2.0)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 django>=1.11,<3.0
 djangorestframework<4.0
-social-auth-core<2.0
+social-auth-core<=3.0
 social-auth-app-django>=3.1.0,<4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 django>=1.11,<3.0
 djangorestframework<4.0
-social-auth-core<=3.0
+social-auth-core<4.0
 social-auth-app-django>=3.1.0,<4.0


### PR DESCRIPTION
This is a PR for https://github.com/st4lk/django-rest-social-auth/issues/73.
