### PR TITLE
Add support for djangorestframework-simplejwt

### DIFF
--- a/rest_social_auth/urls_simplejwt_pair.py
+++ b/rest_social_auth/urls_simplejwt_pair.py
@@ -1,0 +1,9 @@
+from django.conf.urls import url
+
+from . import views
+
+
+urlpatterns = (
+    url(r'^social/jwt-pair/(?:(?P<provider>[a-zA-Z0-9_-]+)/?)?$',
+        views.SocialSimpleJWTPairOnlyAuthView.as_view(),
+        name='login_social_simplejwt_pair'),)

--- a/rest_social_auth/urls_simplejwt_sliding.py
+++ b/rest_social_auth/urls_simplejwt_sliding.py
@@ -1,0 +1,9 @@
+from django.conf.urls import url
+
+from . import views
+
+
+urlpatterns = (
+    url(r'^social/jwt-sliding/(?:(?P<provider>[a-zA-Z0-9_-]+)/?)?$',
+        views.SocialSimpleJWTSlidingOnlyAuthView.as_view(),
+        name='login_social_simplejwt_sliding'),)

--- a/rest_social_auth/views.py
+++ b/rest_social_auth/views.py
@@ -29,7 +29,8 @@ from requests.exceptions import HTTPError
 from .serializers import (
     OAuth2InputSerializer, OAuth1InputSerializer, UserSerializer,
     TokenSerializer, UserTokenSerializer, JWTSerializer, UserJWTSerializer,
-    KnoxSerializer, UserKnoxSerializer
+    KnoxSerializer, UserKnoxSerializer, SimpleJWTObtainSlidingSerializer,
+    SimpleJWTObtainPairSerializer
 )
 
 
@@ -255,3 +256,11 @@ class SocialKnoxOnlyAuthView(KnoxAuthMixin, BaseSocialAuthView):
 
 class SocialKnoxUserAuthView(KnoxAuthMixin, BaseSocialAuthView):
     serializer_class = UserKnoxSerializer
+
+
+class SocialSimpleJWTPairOnlyAuthView(BaseSocialAuthView):
+    serializer_class = SimpleJWTObtainPairSerializer
+
+
+class SocialSimpleJWTSlidingOnlyAuthView(BaseSocialAuthView):
+    serializer_class = SimpleJWTObtainSlidingSerializer


### PR DESCRIPTION
Since in the [Rest Framework Documentation] currently simplejwt is listed as package for implementing JWT with DRF I think this package should support that as wel.

This PR contains the necessary changes to support that. However, it does need an update to the README and should add some tests. Since I don't have the time right now to add those as well I added the PR without those.

Fixes #74 

[rest framework documentation]: https://www.django-rest-framework.org/api-guide/authentication/#json-web-token-authentication