### PR TITLE
Add runsslserver dependency [fixes #104]

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,6 +487,13 @@ There is an [example project](https://github.com/st4lk/django-rest-social-auth/t
     git clone https://github.com/st4lk/django-rest-social-auth.git
     ```
 
+- make sure all dependencies are installed
+
+    ```bash
+    pip install -r requirements.txt
+    pip install -r requirements_test.txt
+    ```
+
 - step in example_project/
 
     ```bash

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,6 +5,8 @@ master
 ------
 - Fix facebook integration in example project: serve with fake TLS certificate
 
+Issues: #104
+
 v2.2.0
 ------
 - Update license, use MIT

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -2,3 +2,4 @@ pytest-django==3.4.8
 httpretty==0.9.6
 unittest2==1.0.1
 mock==1.3.0
+django-sslserver>=0.20


### PR DESCRIPTION
The actual fix is in https://github.com/st4lk/django-rest-social-auth/commit/460efc08c8fec49d8c9496c5ee49a49ace1a2a29

Here I just fixing forgotten dependecies.