### PR TITLE
modified exclude field in UserSerializer to only exclude the fields t…

### DIFF
--- a/rest_social_auth/serializers.py
+++ b/rest_social_auth/serializers.py
@@ -6,6 +6,15 @@ from rest_framework import serializers
 from rest_framework.authtoken.models import Token
 
 
+# Finding fields to be excluded from User Serializer
+User = get_user_model()
+user_fields = set([field.name for field in User._meta.get_fields()])
+fields_to_exclude = {'is_staff', 'is_active', 'date_joined', 'password', 'last_login',
+                     'user_permissions', 'groups', 'is_superuser'}
+fields_to_exclude &= user_fields
+fields_to_exclude = list(fields_to_exclude)
+
+
 class OAuth2InputSerializer(serializers.Serializer):
 
     provider = serializers.CharField(required=False)
@@ -24,10 +33,7 @@ class UserSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = get_user_model()
-        exclude = (
-            'is_staff', 'is_active', 'date_joined', 'password', 'last_login', 'user_permissions',
-            'groups', 'is_superuser',
-        )
+        exclude = fields_to_exclude
 
 
 class TokenSerializer(serializers.Serializer):

--- a/rest_social_auth/serializers.py
+++ b/rest_social_auth/serializers.py
@@ -12,7 +12,7 @@ user_fields = set([field.name for field in User._meta.get_fields()])
 fields_to_exclude = {'is_staff', 'is_active', 'date_joined', 'password', 'last_login',
                      'user_permissions', 'groups', 'is_superuser'}
 fields_to_exclude &= user_fields
-fields_to_exclude = list(fields_to_exclude)
+fields_to_exclude = tuple(fields_to_exclude)
 
 
 class OAuth2InputSerializer(serializers.Serializer):


### PR DESCRIPTION
Hello, and thanks for creating this very useful project.
This is in response to issue #96 
It raises this error when a field is excluded from `UserSerializer` that is not actually present in user model. Specifically, when a custom user model is implemented by extending the `AbstractBaseUser`.
The fix involves only excluding the fields that are present in the user model.
Take care.