### PR TITLE
url() refactored with path() and re_path()

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,37 +96,37 @@ Quick start
     4.1 [session authentication](http://www.django-rest-framework.org/api-guide/authentication/#sessionauthentication)
 
     ```python
-    url(r'^api/login/', include('rest_social_auth.urls_session')),
+    path('api/login/', include('rest_social_auth.urls_session')),
     ```
 
     4.2 [token authentication](http://www.django-rest-framework.org/api-guide/authentication/#tokenauthentication)
 
     ```python
-    url(r'^api/login/', include('rest_social_auth.urls_token')),
+    path('api/login/', include('rest_social_auth.urls_token')),
     ```
 
     4.3 [jwt authentication](https://github.com/davesque/django-rest-framework-simplejwt)
 
     ```python
-    url(r'^api/login/', include('rest_social_auth.urls_jwt_pair')),
+    path('api/login/', include('rest_social_auth.urls_jwt_pair')),
     ```
 
     or / and
 
     ```python
-    url(r'^api/login/', include('rest_social_auth.urls_jwt_sliding')),
+    path('api/login/', include('rest_social_auth.urls_jwt_sliding')),
     ```
 
     4.3.1 [jwt authentication (deprecated)](http://getblimp.github.io/django-rest-framework-jwt/)
 
     ```python
-    url(r'^api/login/', include('rest_social_auth.urls_jwt')),
+    path('api/login/', include('rest_social_auth.urls_jwt')),
     ```
 
     4.4 [knox authentication](https://github.com/James1345/django-rest-knox/)
 
     ```python
-    url(r'^api/login/', include('rest_social_auth.urls_knox')),
+    path('api/login/', include('rest_social_auth.urls_knox')),
     ```
 
 5. You are ready to login users
@@ -458,7 +458,7 @@ To do it
 
 - define your own url:
 
-        url(r'^api/login/social/$', MySocialView.as_view(), name='social_login'),
+        path('api/login/social/$', MySocialView.as_view(), name='social_login'),
 
 - define your serializer
 

--- a/rest_social_auth/urls_jwt.py
+++ b/rest_social_auth/urls_jwt.py
@@ -1,15 +1,15 @@
-from django.conf.urls import url
+from django.urls import re_path
 
 from . import views
 
 
 urlpatterns = (
     # returns jwt + user_data
-    url(r'^social/jwt_user/(?:(?P<provider>[a-zA-Z0-9_-]+)/?)?$',
-        views.SocialJWTUserAuthView.as_view(),
-        name='login_social_jwt_user'),
+    re_path(r'^social/jwt_user/(?:(?P<provider>[a-zA-Z0-9_-]+)/?)?$',
+            views.SocialJWTUserAuthView.as_view(),
+            name='login_social_jwt_user'),
 
     # returns jwt only
-    url(r'^social/jwt/(?:(?P<provider>[a-zA-Z0-9_-]+)/?)?$',
-        views.SocialJWTOnlyAuthView.as_view(),
-        name='login_social_jwt'),)
+    re_path(r'^social/jwt/(?:(?P<provider>[a-zA-Z0-9_-]+)/?)?$',
+            views.SocialJWTOnlyAuthView.as_view(),
+            name='login_social_jwt'),)

--- a/rest_social_auth/urls_jwt_pair.py
+++ b/rest_social_auth/urls_jwt_pair.py
@@ -1,15 +1,15 @@
-from django.conf.urls import url
+from django.urls import re_path
 
 from . import views
 
 
 urlpatterns = (
     # returns token only
-    url(r'^social/jwt-pair/(?:(?P<provider>[a-zA-Z0-9_-]+)/?)?$',
-        views.SocialJWTPairOnlyAuthView.as_view(),
-        name='login_social_jwt_pair'),
+    re_path(r'^social/jwt-pair/(?:(?P<provider>[a-zA-Z0-9_-]+)/?)?$',
+            views.SocialJWTPairOnlyAuthView.as_view(),
+            name='login_social_jwt_pair'),
     # returns token + user_data
-    url(r'^social/jwt-pair-user/(?:(?P<provider>[a-zA-Z0-9_-]+)/?)?$',
-        views.SocialJWTPairUserAuthView.as_view(),
-        name='login_social_jwt_pair_user'),
+    re_path(r'^social/jwt-pair-user/(?:(?P<provider>[a-zA-Z0-9_-]+)/?)?$',
+            views.SocialJWTPairUserAuthView.as_view(),
+            name='login_social_jwt_pair_user'),
 )

--- a/rest_social_auth/urls_jwt_sliding.py
+++ b/rest_social_auth/urls_jwt_sliding.py
@@ -1,15 +1,15 @@
-from django.conf.urls import url
+from django.urls import re_path
 
 from . import views
 
 
 urlpatterns = (
     # returns token only
-    url(r'^social/jwt-sliding/(?:(?P<provider>[a-zA-Z0-9_-]+)/?)?$',
-        views.SocialJWTSlidingOnlyAuthView.as_view(),
-        name='login_social_jwt_sliding'),
+    re_path(r'^social/jwt-sliding/(?:(?P<provider>[a-zA-Z0-9_-]+)/?)?$',
+            views.SocialJWTSlidingOnlyAuthView.as_view(),
+            name='login_social_jwt_sliding'),
     # returns token + user_data
-    url(r'^social/jwt-sliding-user/(?:(?P<provider>[a-zA-Z0-9_-]+)/?)?$',
-        views.SocialJWTSlidingUserAuthView.as_view(),
-        name='login_social_jwt_sliding_user'),
+    re_path(r'^social/jwt-sliding-user/(?:(?P<provider>[a-zA-Z0-9_-]+)/?)?$',
+            views.SocialJWTSlidingUserAuthView.as_view(),
+            name='login_social_jwt_sliding_user'),
 )

--- a/rest_social_auth/urls_knox.py
+++ b/rest_social_auth/urls_knox.py
@@ -1,16 +1,16 @@
-from django.conf.urls import url
+from django.urls import re_path
 
 from . import views
 
 
 urlpatterns = (
     # returns knox token + user_data
-    url(r'^social/knox_user/(?:(?P<provider>[a-zA-Z0-9_-]+)/?)?$',
-        views.SocialKnoxUserAuthView.as_view(),
-        name='login_social_knox_user'),
+    re_path(r'^social/knox_user/(?:(?P<provider>[a-zA-Z0-9_-]+)/?)?$',
+            views.SocialKnoxUserAuthView.as_view(),
+            name='login_social_knox_user'),
 
     # returns knox token only
-    url(r'^social/knox/(?:(?P<provider>[a-zA-Z0-9_-]+)/?)?$',
-        views.SocialKnoxOnlyAuthView.as_view(),
-        name='login_social_knox'),
+    re_path(r'^social/knox/(?:(?P<provider>[a-zA-Z0-9_-]+)/?)?$',
+            views.SocialKnoxOnlyAuthView.as_view(),
+            name='login_social_knox'),
 )

--- a/rest_social_auth/urls_session.py
+++ b/rest_social_auth/urls_session.py
@@ -1,9 +1,9 @@
-from django.conf.urls import url
+from django.urls import re_path
 
 from . import views
 
 
 urlpatterns = (
-    url(r'^social/session/(?:(?P<provider>[a-zA-Z0-9_-]+)/?)?$',
-        views.SocialSessionAuthView.as_view(),
-        name='login_social_session'),)
+    re_path(r'^social/session/(?:(?P<provider>[a-zA-Z0-9_-]+)/?)?$',
+            views.SocialSessionAuthView.as_view(),
+            name='login_social_session'),)

--- a/rest_social_auth/urls_token.py
+++ b/rest_social_auth/urls_token.py
@@ -1,15 +1,15 @@
-from django.conf.urls import url
+from django.urls import re_path
 
 from . import views
 
 
 urlpatterns = (
     # returns token + user_data
-    url(r'^social/token_user/(?:(?P<provider>[a-zA-Z0-9_-]+)/?)?$',
-        views.SocialTokenUserAuthView.as_view(),
-        name='login_social_token_user'),
+    re_path(r'^social/token_user/(?:(?P<provider>[a-zA-Z0-9_-]+)/?)?$',
+            views.SocialTokenUserAuthView.as_view(),
+            name='login_social_token_user'),
 
     # returns token only
-    url(r'^social/token/(?:(?P<provider>[a-zA-Z0-9_-]+)/?)?$',
-        views.SocialTokenOnlyAuthView.as_view(),
-        name='login_social_token'),)
+    re_path(r'^social/token/(?:(?P<provider>[a-zA-Z0-9_-]+)/?)?$',
+            views.SocialTokenOnlyAuthView.as_view(),
+            name='login_social_token'),)


### PR DESCRIPTION
From Django 2.0 path() and re_path() are being used and url() will be soon deprecated. django.conf.urls.url() will be removed will be from Django 4.0. 