### PR TITLE
Add compatibility for social core and app 4.x

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 django>=2.2,<4.0
 djangorestframework<4.0
-social-auth-core>=3.0,<4.0
-social-auth-app-django>=3.1.0,<4.0
+social-auth-core>=3.0,<4.1
+social-auth-app-django>=3.1.0,<4.1

--- a/setup.py
+++ b/setup.py
@@ -61,10 +61,10 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Topic :: Utilities',
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,23 +1,27 @@
 [tox]
 envlist=
-    py{35}-django{22},
-    py{36}-django{22, 30, 31}
-    py{37}-django{22, 30, 31}
-    py{38}-django{22, 30, 31}
+    py{36}-django{22, 30, 31}-core{30, 33, 34, 40}-coreapp{3, 4}
+    py{37}-django{22, 30, 31}-core{30, 33, 34, 40}-coreapp{3, 4}
+    py{38}-django{22, 30, 31}-core{30, 33, 34, 40}-coreapp{3, 4}
+    py{39}-django{22, 30, 31}-core{30, 33, 34, 40}-coreapp{3, 4}
 
 [testenv]
 setenv =
     PYTHONPATH = {toxinidir}/example_project
     LC_ALL = en_US.utf-8
 basepython =
-    py35: python3.5
     py36: python3.6
     py37: python3.7
     py38: python3.8
+    py38: python3.9
 deps =
     djangorestframework<4.0
-    social-auth-core==3.0.0
-    social-auth-app-django==3.1.0
+    core30: social-auth-core>=3.0,<3.1
+    core33: social-auth-core>=3.3,<3.4
+    core34: social-auth-core>=3.4,<3.5
+    core40: social-auth-core>=4.0,<4.1
+    coreapp3: social-auth-app-django>=3.1,<4
+    coreapp4: social-auth-app-django>=4,<4.1
     djangorestframework-jwt
     djangorestframework_simplejwt
     django-rest-knox<5.0.0


### PR DESCRIPTION
Both `social-auth-core` and `social-auth-app-django` have been updated to v4.

Also dropping python 3.5 support since it is EOL since [September 5th, 2020](https://www.python.org/downloads/release/python-3510/).