### PR TITLE
Add compatibility for social-auth-app-django 5.x.x

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,8 @@ native-install-python-versions: .install-python-versions
 	PYENV_ROOT=$(PROJECT_PATH_NATIVE)/.pyenv $(PROJECT_PATH_NATIVE)/.pyenv/bin/pyenv install -s 3.6.10
 	PYENV_ROOT=$(PROJECT_PATH_NATIVE)/.pyenv $(PROJECT_PATH_NATIVE)/.pyenv/bin/pyenv install -s 3.7.7
 	PYENV_ROOT=$(PROJECT_PATH_NATIVE)/.pyenv $(PROJECT_PATH_NATIVE)/.pyenv/bin/pyenv install -s 3.8.2
-	$(PROJECT_PATH_NATIVE)/.pyenv/bin/pyenv global system 3.5.9 3.6.10 3.7.7 3.8.2
+	PYENV_ROOT=$(PROJECT_PATH_NATIVE)/.pyenv $(PROJECT_PATH_NATIVE)/.pyenv/bin/pyenv install -s 3.9.7
+	$(PROJECT_PATH_NATIVE)/.pyenv/bin/pyenv global system 3.5.9 3.6.10 3.7.7 3.8.2 3.9.7
 	touch $@
 
 native-test-tox: native-install-python-versions native-clean

--- a/example_project/config/urls.py
+++ b/example_project/config/urls.py
@@ -1,26 +1,28 @@
-from django.conf.urls import include, url
+from django.conf.urls import include, re_path
 from django.contrib import admin
 
 from users import views
 
 urlpatterns = [
-    url(r'^$', views.HomeSessionView.as_view(), name='home'),
-    url(r'^session/$', views.HomeSessionView.as_view(), name='home_session'),
-    url(r'^token/$', views.HomeTokenView.as_view(), name='home_token'),
-    url(r'^jwt/$', views.HomeJWTView.as_view(), name='home_jwt'),
-    url(r'^knox/$', views.HomeKnoxView.as_view(), name='home_knox'),
+    re_path(r'^$', views.HomeSessionView.as_view(), name='home'),
+    re_path(r'^session/$', views.HomeSessionView.as_view(), name='home_session'),
+    re_path(r'^token/$', views.HomeTokenView.as_view(), name='home_token'),
+    re_path(r'^jwt/$', views.HomeJWTView.as_view(), name='home_jwt'),
+    re_path(r'^knox/$', views.HomeKnoxView.as_view(), name='home_knox'),
 
-    url(r'^api/login/', include('rest_social_auth.urls_session')),
-    url(r'^api/login/', include('rest_social_auth.urls_token')),
-    url(r'^api/login/', include('rest_social_auth.urls_jwt_pair')),
-    url(r'^api/login/', include('rest_social_auth.urls_jwt_sliding')),
-    url(r'^api/login/', include('rest_social_auth.urls_knox')),
+    re_path(r'^api/login/', include('rest_social_auth.urls_session')),
+    re_path(r'^api/login/', include('rest_social_auth.urls_token')),
+    re_path(r'^api/login/', include('rest_social_auth.urls_jwt_pair')),
+    re_path(r'^api/login/', include('rest_social_auth.urls_jwt_sliding')),
+    re_path(r'^api/login/', include('rest_social_auth.urls_knox')),
 
-    url(r'^api/logout/session/$', views.LogoutSessionView.as_view(), name='logout_session'),
-    url(r'^api/user/session/', views.UserSessionDetailView.as_view(), name="current_user_session"),
-    url(r'^api/user/token/', views.UserTokenDetailView.as_view(), name="current_user_token"),
-    url(r'^api/user/jwt/', views.UserJWTDetailView.as_view(), name="current_user_jwt"),
-    url(r'^api/user/knox/', views.UserKnoxDetailView.as_view(), name="current_user_knox"),
+    re_path(r'^api/logout/session/$', views.LogoutSessionView.as_view(), name='logout_session'),
+    re_path(r'^api/user/session/',
+            views.UserSessionDetailView.as_view(),
+            name="current_user_session"),
+    re_path(r'^api/user/token/', views.UserTokenDetailView.as_view(), name="current_user_token"),
+    re_path(r'^api/user/jwt/', views.UserJWTDetailView.as_view(), name="current_user_jwt"),
+    re_path(r'^api/user/knox/', views.UserKnoxDetailView.as_view(), name="current_user_knox"),
 
-    url(r'^admin/', admin.site.urls),
+    re_path(r'^admin/', admin.site.urls),
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 django>=2.2,<4.0
 djangorestframework<4.0
 social-auth-core>=4.0,<5.0
-social-auth-app-django>=4.0,<5.0
+social-auth-app-django>=5.0,<6.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 envlist=
-    py{36}-django{22, 30, 31}
-    py{37}-django{22, 30, 31}
-    py{38}-django{22, 30, 31}
-    py{39}-django{22, 30, 31}
+    py{36}-django{22, 30, 31, 32}
+    py{37}-django{22, 30, 31, 32}
+    py{38}-django{22, 30, 31, 32}
+    py{39}-django{22, 30, 31, 32}
 
 [testenv]
 setenv =
@@ -17,20 +17,21 @@ basepython =
 deps =
     py36: cryptography<3.4
     djangorestframework<4.0
-    social-auth-core==4.0.3
-    social-auth-app-django==4.0.0
+    social-auth-core==4.1.0
+    social-auth-app-django==5.0.0
     djangorestframework-jwt
     djangorestframework_simplejwt
     django-rest-knox<5.0.0
     django22: Django>=2.2.17,<2.3
     django30: Django>=3.0,<3.1
     django31: Django>=3.1,<3.2
+    django32: Django>=3.2,<3.3
     py37-django22: coverage
     -rrequirements_test.txt
 commands =
     py.test {posargs}
 
-[testenv:py36-django{22, 30, 31}]
+[testenv:py36-django{22, 30, 31, 32}]
 commands =
     py.test --ignore=tests/test_simple_jwt.py {posargs}
 


### PR DESCRIPTION
Thanks for the great package!

I checked the newer version of social-auth-app-django and it does not seem to break anything here but fixes some deprecation issues with more recent Django versions. I ran the provided tox tests and they all passed. While doing that I fixed some test warnings, added Django 3.2 to the test environment matrix and fixed issue with Python 3.9 tests not running.

Closes #149 