### PR TITLE
Added `request` parameter into BaseSocialAuthView.get_object() return parameters

### DIFF
--- a/rest_social_auth/views.py
+++ b/rest_social_auth/views.py
@@ -163,7 +163,7 @@ class BaseSocialAuthView(GenericAPIView):
         if self.oauth_v1():
             self.save_token_param_in_session()
 
-        user = self.request.backend.complete(user=user)
+        user = self.request.backend.complete(user=user, request=self.request)
         return user
 
     def save_token_param_in_session(self):


### PR DESCRIPTION
Most Django authentication backends, like [django-axes `AxesStandAloneBackend`](https://github.com/jazzband/django-axes/blob/master/axes/backends.py), require the `request` parameter in order to work properly. I needed to integrate axes into a project so i forked the repo, but I think it could be also be useful to others.